### PR TITLE
Remove whitespace, clean up code and fix bug.

### DIFF
--- a/btchip/__init__.py
+++ b/btchip/__init__.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
-*   BTChip Bitcoin Hardware Wallet Python API 
+*******************************************************************************
+*   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at

--- a/btchip/bitcoinTransaction.py
+++ b/btchip/bitcoinTransaction.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -35,7 +35,7 @@ class bitcoinInput:
 			offset += scriptSize['size']
 			self.script = buf[offset:offset + scriptSize['value']]
 			offset += scriptSize['value']
-			self.sequence = buf[offset:offset + 4]			
+			self.sequence = buf[offset:offset + 4]
 			offset += 4
 			bufferOffset['offset'] = offset
 
@@ -51,13 +51,13 @@ class bitcoinInput:
 		buf =  "Prevout : " + hexlify(self.prevOut) + "\r\n"
 		buf += "Script : " + hexlify(self.script) + "\r\n"
 		buf += "Sequence : " + hexlify(self.sequence) + "\r\n"
-		return buf		
+		return buf
 
 class bitcoinOutput:
 
 	def __init__(self, bufferOffset=None):
 		self.amount = ""
-		self.script = ""		
+		self.script = ""
 		if bufferOffset is not None:
 			buf = bufferOffset['buffer']
 			offset = bufferOffset['offset']
@@ -79,7 +79,7 @@ class bitcoinOutput:
 	def __str__(self):
 		buf =  "Amount : " + hexlify(self.amount) + "\r\n"
 		buf += "Script : " + hexlify(self.script) + "\r\n"
-		return buf		
+		return buf
 
 
 class bitcoinTransaction:
@@ -101,7 +101,7 @@ class bitcoinTransaction:
 				self.inputs.append(bitcoinInput(tmp))
 				offset = tmp['offset']
 			outputSize = readVarint(data, offset)
-			offset += outputSize['size']				
+			offset += outputSize['size']
 			numOutputs = outputSize['value']
 			for i in range(numOutputs):
 				tmp = { 'buffer': data, 'offset' : offset}
@@ -135,4 +135,4 @@ class bitcoinTransaction:
 			buf += str(troutput)
 			index+=1
 		buf += "Locktime : " + hexlify(self.lockTime) + "\r\n"
-		return buf		
+		return buf

--- a/btchip/bitcoinVarint.py
+++ b/btchip/bitcoinVarint.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -48,7 +48,7 @@ def writeVarint(value, buffer):
 		buffer.append((value >> 8) & 0xff)
 		buffer.append((value >> 16) & 0xff)
 		buffer.append((value >> 24) & 0xff)
-	else:		
+	else:
 		raise BTChipException("unsupported encoding")
 	return buffer
 

--- a/btchip/btchip.py
+++ b/btchip/btchip.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -64,7 +64,7 @@ class btchip:
 
 	QWERTY_KEYMAP = bytearray("000000000000000000000000760f00d4ffffffc7000000782c1e3420212224342627252e362d3738271e1f202122232425263333362e37381f0405060708090a0b0c0d0e0f101112131415161718191a1b1c1d2f3130232d350405060708090a0b0c0d0e0f101112131415161718191a1b1c1d2f313035".decode('hex'))
 	QWERTZ_KEYMAP = bytearray("000000000000000000000000760f00d4ffffffc7000000782c1e3420212224342627252e362d3738271e1f202122232425263333362e37381f0405060708090a0b0c0d0e0f101112131415161718191a1b1d1c2f3130232d350405060708090a0b0c0d0e0f101112131415161718191a1b1d1c2f313035".decode('hex'))
-	AZERTY_KEYMAP = bytearray("08000000010000200100007820c8ffc3feffff07000000002c38202030341e21222d352e102e3637271e1f202122232425263736362e37101f1405060708090a0b0c0d0e0f331112130415161718191d1b1c1a2f64302f2d351405060708090a0b0c0d0e0f331112130415161718191d1b1c1a2f643035".decode('hex'))	
+	AZERTY_KEYMAP = bytearray("08000000010000200100007820c8ffc3feffff07000000002c38202030341e21222d352e102e3637271e1f202122232425263736362e37101f1405060708090a0b0c0d0e0f331112130415161718191d1b1c1a2f64302f2d351405060708090a0b0c0d0e0f331112130415161718191d1b1c1a2f643035".decode('hex'))
 
 	def __init__(self, dongle):
 		self.dongle = dongle
@@ -103,7 +103,7 @@ class btchip:
 		# Header
 		apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_GET_TRUSTED_INPUT, 0x00, 0x00 ]
 		params = bytearray(("%.8x" % (index)).decode('hex'))
-		params.extend(transaction.version)		
+		params.extend(transaction.version)
 		writeVarint(len(transaction.inputs), params)
 		apdu.append(len(params))
 		apdu.extend(params)
@@ -153,9 +153,9 @@ class btchip:
 		apdu.extend(params)
 		self.dongle.exchange(bytearray(apdu))
 		# Loop for each input
-		currentIndex = 0		
+		currentIndex = 0
 		for passedOutput in outputList:
-			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_START, 0x80, 0x00 ]	
+			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_START, 0x80, 0x00 ]
 			params = []
 			script = redeemScript
 			if passedOutput['trustedInput']:
@@ -171,7 +171,7 @@ class btchip:
 			params.extend(bytearray([0xFF, 0xFF, 0xFF, 0xFF])) # default sequence
 			apdu.append(len(params))
 			apdu.extend(params)
-			self.dongle.exchange(bytearray(apdu))		
+			self.dongle.exchange(bytearray(apdu))
 			currentIndex += 1
 
 	def finalizeInput(self, outputAddress, amount, fees, changePath):
@@ -186,7 +186,7 @@ class btchip:
 		params.extend(donglePath)
 		response = apdu.append(len(params))
 		apdu.extend(params)
-		response = self.dongle.exchange(bytearray(apdu))		
+		response = self.dongle.exchange(bytearray(apdu))
 		result['confirmationNeeded'] = response[1 + response[0]] == 0x01
 		result['outputData'] = response[1 : 1 + response[0]]
 		return result
@@ -205,14 +205,14 @@ class btchip:
 			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_FINALIZE_FULL, \
 			p1, 0x00, dataLength ]
 			apdu.extend(outputData[offset : offset + dataLength])
-			response = self.dongle.exchange(bytearray(apdu))		
+			response = self.dongle.exchange(bytearray(apdu))
 			offset += dataLength
 		result['confirmationNeeded'] = response[0] == 0x01
 		return result
 
 	def untrustedHashSign(self, path, pin="", lockTime=0, sighashType=0x01):
 		donglePath = parse_bip32_path(path)
-		apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_SIGN, 0x00, 0x00 ]		
+		apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_SIGN, 0x00, 0x00 ]
 		params = []
 		params.extend(donglePath)
 		params.append(len(pin))
@@ -221,7 +221,7 @@ class btchip:
 		params.append(sighashType)
 		apdu.append(len(params))
 		apdu.extend(params)
-		result = self.dongle.exchange(bytearray(apdu))		
+		result = self.dongle.exchange(bytearray(apdu))
 		result[0] = 0x30
 		return result
 
@@ -231,11 +231,11 @@ class btchip:
 		apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_SIGN_MESSAGE, 0x00, 0x00 ]
 		params = []
 		params.extend(donglePath)
-		params.append(len(message))		
+		params.append(len(message))
 		params.extend(bytearray(message))
 		apdu.append(len(params))
 		apdu.extend(params)
-		response = self.dongle.exchange(bytearray(apdu))		
+		response = self.dongle.exchange(bytearray(apdu))
 		result['confirmationNeeded'] = response[0] == 0x01
 		return result
 
@@ -249,8 +249,8 @@ class btchip:
 			params.append(0x00)
 		apdu.append(len(params))
 		apdu.extend(params)
-		response = self.dongle.exchange(bytearray(apdu))		
-		return response		
+		response = self.dongle.exchange(bytearray(apdu))
+		return response
 
 	def setup(self, operationModeFlags, featuresFlag, keyVersion, keyVersionP2SH, userPin, wipePin, keymapEncoding, seed=None, developerKey=None):
 		result = {}
@@ -262,7 +262,7 @@ class btchip:
 			params.append(len(wipePin))
 			params.extend(bytearray(wipePin))
 		else:
-			params.append(0x00)		
+			params.append(0x00)
 		if seed is not None:
 			if len(seed) < 32 or len(seed) > 64:
 				raise BTChipException("Invalid seed length")
@@ -271,13 +271,13 @@ class btchip:
 		else:
 			params.append(0x00)
 		if developerKey is not None:
-			params.append(len(developerKey))		
+			params.append(len(developerKey))
 			params.extend(developerKey)
 		else:
 			params.append(0x00)
 		apdu.append(len(params))
 		apdu.extend(params)
-		response = self.dongle.exchange(bytearray(apdu))		
+		response = self.dongle.exchange(bytearray(apdu))
 		result['trustedInputKey'] = response[0:16]
 		result['developerKey'] = response[16:]
 		self.setKeymapEncoding(keymapEncoding)
@@ -300,7 +300,7 @@ class btchip:
 			and operationMode <> btchip.OPERATION_MODE_RELAXED_WALLET \
 			and operationMode <> btchip.OPERATION_MODE_SERVER \
 			and operationMode <> btchip.OPERATION_MODE_DEVELOPER:
-			raise BTChipException("Invalid operation mode")			
+			raise BTChipException("Invalid operation mode")
 		apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_SET_OPERATION_MODE, 0x00, 0x00, 0x01, operationMode ]
 		self.dongle.exchange(bytearray(apdu))
 
@@ -317,7 +317,7 @@ class btchip:
 				raise
 		result['compressedKeys'] = (response[0] == 0x01)
 		result['version'] = "%d.%d.%d" % (((response[1] << 8) + response[2]), response[3], response[4])
-		return result				
+		return result
 
 	def getRandom(self, size):
 		if size > 255:
@@ -348,10 +348,10 @@ class btchip:
 		apdu.append(len(encodedPrivateKey))
 		apdu.extend(encodedPrivateKey)
 		response = self.dongle.exchange(bytearray(apdu))
-                offset = 1 
+                offset = 1
                 result['publicKey'] = response[offset + 1 : offset + 1 + response[offset]]
                 offset = offset + 1 + response[offset]
-		if response[0] == 0x02: 
+		if response[0] == 0x02:
 			result['chainCode'] = response[offset : offset + 32]
 			offset = offset + 32
 			result['depth'] = response[offset]

--- a/btchip/btchipComm.py
+++ b/btchip/btchipComm.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -56,7 +56,7 @@ class HIDDongle(Dongle, DongleWait):
 	def __init__(self, device, debug=False):
 		self.device = device
 		self.debug = debug
-		self.waitImpl = self 
+		self.waitImpl = self
 		try:
 			self.device.detach_kernel_driver(0)
 		except:
@@ -68,13 +68,13 @@ class HIDDongle(Dongle, DongleWait):
 		padSize = len(apdu) % 64
 		tmp = apdu
 		if padSize <> 0:
-			tmp.extend([0] * (64 - padSize))		
+			tmp.extend([0] * (64 - padSize))
 		offset = 0
 		while(offset <> len(tmp)):
 			self.device.write(0x02, tmp[offset:offset + 64], 0)
 			offset += 64
 		dataLength = 0
-		result = self.waitImpl.waitFirstResponse(timeout) 
+		result = self.waitImpl.waitFirstResponse(timeout)
 		if result[0] == 0x61: # 61xx : data available
 			dataLength = result[1]
 			dataLength += 2
@@ -94,7 +94,7 @@ class HIDDongle(Dongle, DongleWait):
 		sw = (result[swOffset] << 8) + result[swOffset + 1]
 		response = result[2 : dataLength + 2]
 		if self.debug:
-			print "<= %s%.2x" % (hexlify(response), sw)		
+			print "<= %s%.2x" % (hexlify(response), sw)
 		if sw <> 0x9000:
 			raise BTChipException("Invalid status %04x" % sw, sw)
 		return response
@@ -123,7 +123,7 @@ class WinUSBDongle(Dongle, DongleWait):
 		if self.debug:
 			print "=> %s" % hexlify(apdu)
 		self.device.write(0x02, apdu, 0)
-		result = self.waitImpl.waitFirstResponse(timeout) 
+		result = self.waitImpl.waitFirstResponse(timeout)
 		dataLength = 0
 		if result[0] == 0x61: # 61xx : data available
 			dataLength = result[1]
@@ -133,13 +133,13 @@ class WinUSBDongle(Dongle, DongleWait):
 		sw = (result[swOffset] << 8) + result[swOffset + 1]
 		response = result[2 : dataLength + 2]
 		if self.debug:
-			print "<= %s%.2x" % (hexlify(response), sw)		
+			print "<= %s%.2x" % (hexlify(response), sw)
 		if sw <> 0x9000:
 			raise BTChipException("Invalid status %04x" % sw, sw)
 		return response
 
 	def waitFirstResponse(self, timeout):
-		return bytearray(self.device.read(0x82, 260, timeout))
+		return bytearray(self.device.read(0x82, 260, timeout=timeout))
 
 	def close(self):
 		try:
@@ -152,7 +152,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 	def __init__(self, device, debug=False):
 		self.device = device
 		self.debug = debug
-		self.waitImpl = self 
+		self.waitImpl = self
 
 	def exchange(self, apdu, timeout=20000):
 		if self.debug:
@@ -160,13 +160,13 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		padSize = len(apdu) % 64
 		tmp = apdu
 		if padSize <> 0:
-			tmp.extend([0] * (64 - padSize))		
+			tmp.extend([0] * (64 - padSize))
 		offset = 0
 		while(offset <> len(tmp)):
 			self.device.write(tmp[offset:offset + 64])
 			offset += 64
 		dataLength = 0
-		result = self.waitImpl.waitFirstResponse(timeout) 
+		result = self.waitImpl.waitFirstResponse(timeout)
 		if result[0] == 0x61: # 61xx : data available
 			self.device.set_nonblocking(False)
 			dataLength = result[1]
@@ -188,7 +188,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		sw = (result[swOffset] << 8) + result[swOffset + 1]
 		response = result[2 : dataLength + 2]
 		if self.debug:
-			print "<= %s%.2x" % (hexlify(response), sw)		
+			print "<= %s%.2x" % (hexlify(response), sw)
 		if sw <> 0x9000:
 			raise BTChipException("Invalid status %04x" % sw, sw)
 		return response
@@ -201,7 +201,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 			if not len(data):
 				if time.time() - start > timeout:
 					raise BTChipException("Timeout")
-				time.sleep(0.02)				
+				time.sleep(0.02)
 		return bytearray(data)
 
 	def close(self):
@@ -217,19 +217,19 @@ def getDongle(debug=False):
 		if hidDevice['vendor_id'] == 0x2581 and hidDevice['product_id'] == 0x2b7c:
 			hidDevicePath = hidDevice['path']
 		if hidDevice['vendor_id'] == 0x2581 and hidDevice['product_id'] == 0x1807:
-			hidDevicePath = hidDevice['path']		
+			hidDevicePath = hidDevice['path']
 	if hidDevicePath is not None:
 		dev = hid.device()
 		dev.open_path(hidDevicePath)
 		dev.set_nonblocking(True)
-		return HIDDongleHIDAPI(dev, debug)				
-	if WINUSB:	
+		return HIDDongleHIDAPI(dev, debug)
+	if WINUSB:
 		dev = usb.core.find(idVendor=0x2581, idProduct=0x1b7c) # core application, WinUSB
 		if dev is not None:
-			return WinUSBDongle(dev, debug)	
+			return WinUSBDongle(dev, debug)
 		dev = usb.core.find(idVendor=0x2581, idProduct=0x1808) # bootloader, WinUSB
 		if dev is not None:
-			return WinUSBDongle(dev, debug)	
+			return WinUSBDongle(dev, debug)
 		dev = usb.core.find(idVendor=0x2581, idProduct=0x2b7c) # core application, Generic HID
 		if dev is not None:
 			return HIDDongle(dev, debug)

--- a/btchip/btchipException.py
+++ b/btchip/btchipException.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at

--- a/btchip/btchipFirmwareWizard.py
+++ b/btchip/btchipFirmwareWizard.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at

--- a/btchip/btchipHelpers.py
+++ b/btchip/btchipHelpers.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -31,7 +31,7 @@ def satoshi_to_btc(satoshi_count):
 
 def btc_to_satoshi(btc):
     return int(decimal.Decimal(btc) * SATOSHI_PER_COIN)
-# /from pycoin   
+# /from pycoin
 
 def writeUint32BE(value, buffer):
 	buffer.append((value >> 24) & 0xff)

--- a/btchip/btchipPersoWizard.py
+++ b/btchip/btchipPersoWizard.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -58,8 +58,8 @@ def waitDongle(currentDialog, persoData):
 		return True
 	except BTChipException,e:
 		if e.sw == 0x6faa:
-			QMessageBox.information(currentDialog, "BTChip Setup", "Please unplug the dongle and plug it again", "OK")									
-			return False		
+			QMessageBox.information(currentDialog, "BTChip Setup", "Please unplug the dongle and plug it again", "OK")
+			return False
 		if QMessageBox.question(currentDialog, "BTChip setup", "BTChip dongle not found.  It might be in the wrong mode. Try unplugging und plugging it back in again, then press 'OK'", QMessageBox.Yes | QMessageBox.No, QMessageBox.Yes) == QMessageBox.Yes:
 			return False
 		else:
@@ -114,13 +114,13 @@ class SeedDialog(QtGui.QDialog):
 	def processNext(self):
 		self.persoData['seed'] = None
 		if self.ui.RestoreWalletButton.isChecked():
-			# Check if it's an hexa string			
+			# Check if it's an hexa string
 			seedText = str(self.ui.seed.text())
 			if len(seedText) == 0:
 				QMessageBox.warning(self, "Error", "Please enter a seed", "OK")
-				return	
-			if seedText[len(seedText) - 1] == 'X':
-				seedText = seedText[0:len(seedText) - 1]
+				return
+			if seedText[-1] == 'X':
+				seedText = seedText[0:-1]
 			try:
 				self.persoData['seed'] = seedText.decode('hex')
 			except:
@@ -149,14 +149,14 @@ class SecurityDialog(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalization02security.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.NextButton.clicked.connect(self.processNext)
 		self.ui.CancelButton.clicked.connect(self.processCancel)
-	
 
-	def processNext(self):		
+
+	def processNext(self):
 		if (self.ui.pin1.text() <> self.ui.pin2.text()):
 			self.ui.pin1.setText("")
 			self.ui.pin2.setText("")
@@ -164,10 +164,10 @@ class SecurityDialog(QtGui.QDialog):
 			return
 		if (len(self.ui.pin1.text()) < 4):
 			QMessageBox.warning(self, "Error", "PIN must be at least 4 characteres long", "OK")
-			return					
+			return
 		if (len(self.ui.pin1.text()) > 32):
 			QMessageBox.warning(self, "Error", "PIN is too long", "OK")
-			return	
+			return
 		self.persoData['pin'] = str(self.ui.pin1.text())
 		self.persoData['hardened'] = self.ui.HardenedButton.isChecked()
 		dialog = ConfigDialog(self.persoData, self)
@@ -187,12 +187,12 @@ class ConfigDialog(QtGui.QDialog):
 		self.ui.setupUi(self)
 		self.ui.NextButton.clicked.connect(self.processNext)
 		self.ui.CancelButton.clicked.connect(self.processCancel)
-	
+
 	def processNext(self):
 		if (self.ui.qwertyButton.isChecked()):
 			self.persoData['keyboard'] = btchip.QWERTY_KEYMAP
 		elif (self.ui.qwertzButton.isChecked()):
-			self.persoData['keyboard'] = btchip.QWERTZ_KEYMAP 
+			self.persoData['keyboard'] = btchip.QWERTZ_KEYMAP
 		elif (self.ui.azertyButton.isChecked()):
 			self.persoData['keyboard'] = btchip.AZERTY_KEYMAP
 		try:
@@ -206,13 +206,13 @@ class ConfigDialog(QtGui.QDialog):
 			mode = mode | btchip.OPERATION_MODE_SERVER
 		try:
 			self.persoData['client'].setup(mode, btchip.FEATURE_RFC6979, self.persoData['currencyCode'],
-				self.persoData['currencyCodeP2SH'], self.persoData['pin'], None, 
+				self.persoData['currencyCodeP2SH'], self.persoData['pin'], None,
 				self.persoData['keyboard'], self.persoData['seed'])
 		except BTChipException, e:
 			if e.sw == 0x6985:
-				QMessageBox.warning(self, "Error", "Dongle is already set up. Please insert a different one", "OK")				
+				QMessageBox.warning(self, "Error", "Dongle is already set up. Please insert a different one", "OK")
 				return
-		except Exception, e:				
+		except Exception, e:
 				QMessageBox.warning(self, "Error", "Error performing setup", "OK")
 				return
 		if self.persoData['seed'] is None:
@@ -226,13 +226,13 @@ class ConfigDialog(QtGui.QDialog):
 
 	def processCancel(self):
 		self.reject()
-		self.persoData['main'].reject()			
+		self.persoData['main'].reject()
 
 class FinalizeDialog(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalization04finalize.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.FinishButton.clicked.connect(self.finish)
@@ -243,37 +243,37 @@ class FinalizeDialog(QtGui.QDialog):
 			self.reject()
 			self.persoData['main'].reject()
 		attempts = self.persoData['client'].getVerifyPinRemainingAttempts()
-		self.ui.remainingAttemptsLabel.setText("Remaining attempts " + str(attempts))		
+		self.ui.remainingAttemptsLabel.setText("Remaining attempts " + str(attempts))
 
 	def finish(self):
 		if (len(self.ui.pin1.text()) < 4):
 			QMessageBox.warning(self, "Error", "PIN must be at least 4 characteres long", "OK")
-			return					
+			return
 		if (len(self.ui.pin1.text()) > 32):
 			QMessageBox.warning(self, "Error", "PIN is too long", "OK")
-			return	
+			return
 		try:
 			self.persoData['client'].verifyPin(str(self.ui.pin1.text()))
 		except BTChipException, e:
 			if ((e.sw == 0x63c0) or (e.sw == 0x6985)):
-				QMessageBox.warning(self, "Error", "Invalid PIN - dongle has been reset. Please personalize again", "OK")				
+				QMessageBox.warning(self, "Error", "Invalid PIN - dongle has been reset. Please personalize again", "OK")
 				self.reject()
 				self.persoData['main'].reject()
 			if ((e.sw & 0xfff0) == 0x63c0):
 				attempts = e.sw - 0x63c0
-				self.ui.remainingAttemptsLabel.setText("Remaining attempts " + str(attempts))		
-			QMessageBox.warning(self, "Error", "Invalid PIN - please unplug the dongle and plug it again before retrying", "OK")				
+				self.ui.remainingAttemptsLabel.setText("Remaining attempts " + str(attempts))
+			QMessageBox.warning(self, "Error", "Invalid PIN - please unplug the dongle and plug it again before retrying", "OK")
 			try:
 				while not waitDongle(self, self.persoData):
 					pass
 			except Exception, e:
 				self.reject()
 				self.persoData['main'].reject()
-			return			
-		except Exception, e:				
-			QMessageBox.warning(self, "Error", "Unexpected error verifying PIN  - aborting", "OK")			
+			return
+		except Exception, e:
+			QMessageBox.warning(self, "Error", "Unexpected error verifying PIN  - aborting", "OK")
 			self.reject()
-			self.persoData['main'].reject()			
+			self.persoData['main'].reject()
 			return
 		if not self.persoData['hardened']:
 			try:
@@ -284,19 +284,19 @@ class FinalizeDialog(QtGui.QDialog):
 				self.persoData['main'].reject()
 				return
 		QMessageBox.information(self, "BTChip Setup", "Setup completed. Please unplug the dongle and plug it again before use", "OK")
-		self.accept()	
+		self.accept()
 		self.persoData['main'].accept()
 
 class SeedBackupStart(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalizationseedbackup01.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.NextButton.clicked.connect(self.processNext)
-	
-	def processNext(self):		
+
+	def processNext(self):
 		dialog = SeedBackupUnplug(self.persoData, self)
 		self.hide()
 		dialog.exec_()
@@ -305,12 +305,12 @@ class SeedBackupUnplug(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalizationseedbackup02.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.NextButton.clicked.connect(self.processNext)
-	
-	def processNext(self):		
+
+	def processNext(self):
 		dialog = SeedBackupInstructions(self.persoData, self)
 		self.hide()
 		dialog.exec_()
@@ -319,12 +319,12 @@ class SeedBackupInstructions(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalizationseedbackup03.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.NextButton.clicked.connect(self.processNext)
-	
-	def processNext(self):		
+
+	def processNext(self):
 		dialog = SeedBackupVerify(self.persoData, self)
 		self.hide()
 		dialog.exec_()
@@ -333,13 +333,13 @@ class SeedBackupVerify(QtGui.QDialog):
 
 	def __init__(self, persoData, parent = None):
 		QDialog.__init__(self, parent)
-		self.persoData = persoData		
+		self.persoData = persoData
 		self.ui = ui.personalizationseedbackup04.Ui_Dialog()
 		self.ui.setupUi(self)
 		self.ui.seedOkButton.clicked.connect(self.seedOK)
 		self.ui.seedKoButton.clicked.connect(self.seedKO)
-	
-	def seedOK(self):		
+
+	def seedOK(self):
 		dialog = FinalizeDialog(self.persoData, self)
 		self.hide()
 		dialog.exec_()
@@ -356,11 +356,11 @@ class SeedBackupVerify(QtGui.QDialog):
 				self.persoData['client'].verifyPin("0")
 			except BTChipException, e:
 				if e.sw == 0x63c0:
-					QMessageBox.information(self, "BTChip Setup", "Dongle is reset and can be repersonalized", "OK")				
+					QMessageBox.information(self, "BTChip Setup", "Dongle is reset and can be repersonalized", "OK")
 					finished = True
 					pass
 				if e.sw == 0x6faa:
-					QMessageBox.information(self, "BTChip Setup", "Please unplug the dongle and plug it again", "OK")									
+					QMessageBox.information(self, "BTChip Setup", "Please unplug the dongle and plug it again", "OK")
 					pass
 			except Exception, e:
 				pass

--- a/btchip/btchipUtils.py
+++ b/btchip/btchipUtils.py
@@ -1,8 +1,8 @@
 """
-*******************************************************************************    
+*******************************************************************************
 *   BTChip Bitcoin Hardware Wallet Python API
 *   (c) 2014 BTChip - 1BTChip7VfTnrPra5jqci7ejnMguuHogTn
-*   
+*
 *  Licensed under the Apache License, Version 2.0 (the "License");
 *  you may not use this file except in compliance with the License.
 *  You may obtain a copy of the License at
@@ -54,7 +54,7 @@ def get_regular_input_script(sigHashtype, publicKey):
 	if len(sigHashtype) >= 0x4c:
 		raise BTChipException("Invalid sigHashtype")
 	if len(publicKey) >= 0x4c:
-		raise BTChipException("Invalid publicKey")	
+		raise BTChipException("Invalid publicKey")
 	result = [ len(sigHashtype) ]
 	result.extend(sigHashtype)
 	result.append(len(publicKey))
@@ -84,7 +84,7 @@ def get_p2sh_input_script(redeemScript, sigHashtypeList):
 	write_pushed_data_size(redeemScript, result)
 	result.extend(redeemScript)
 	return bytearray(result)
-	
+
 def get_output_script(amountScriptArray):
 	result = [ len(amountScriptArray) ]
 	for amountScript in amountScriptArray:


### PR DESCRIPTION
This largely removes trailing whitespace, improves a minor stylistic issue and fixes a libusb bug where a parameter changed.

`btchipPersoWizard.py` under Ubuntu 14.04 **does not** work for me without the bugfix.
