### PR TITLE
Don't include usb.core in btchipPersoWizard.py

### DIFF
--- a/btchip/btchipPersoWizard.py
+++ b/btchip/btchipPersoWizard.py
@@ -28,7 +28,6 @@ try:
 except:
 	MNEMONIC = False
 
-from usb.core import USBError
 from btchipComm import getDongle, DongleWait
 from btchip import btchip
 from btchipUtils import compress_public_key,format_transaction, get_regular_input_script


### PR DESCRIPTION
It's useless and it enforce pyusb to be a mandatory depends, but on not-Windows it's not needed.