### PR TITLE
fix python `if` syntax in `format_transaction`

### DIFF
--- a/btchip/btchipUtils.py
+++ b/btchip/btchipUtils.py
@@ -43,7 +43,7 @@ def format_transaction(dongleOutputData, trustedInputsAndInputScripts, version=0
 		newInput = bitcoinInput()
 		newInput.prevOut = item[0][4:4+36]
 		newInput.script = item[1]
-		if len(item > 2):
+		if len(item) > 2:
 			newInput.sequence = bytearray(item[2].decode('hex'))
 		else:
 			newInput.sequence = bytearray([0xff, 0xff, 0xff, 0xff])


### PR DESCRIPTION
This fixes `format_transaction`.

Prior to this fix, every call to `format_transaction` fails with

```python
TypeError: object of type 'bool' has no len()
```

Fixes Electrum-LTC support for Ledger Nano S.