### PR TITLE
Adjust instructions for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Building/Installing on FreeBSD
   
 On FreeBSD you can install the packages:
 
-    pkg install security/py-btchip
+    pkg install security/py-btchip-python
 
 or build via ports:
 
-    cd /usr/ports/security/py-btchip
+    cd /usr/ports/security/py-btchip-python
     make install clean
 
   


### PR DESCRIPTION
Short after the FreeBSD port was added it had to be renamed by policy in order to have the same name as published on PyPI. This change adjusts the Building/Installing instructions accordingly.