### PR TITLE
Avoided bare except

### DIFF
--- a/btchip/btchip.py
+++ b/btchip/btchip.py
@@ -85,12 +85,12 @@ class btchip:
 				self.scriptBlockLength = 50
 			else:
 				self.scriptBlockLength = 255
-		except:
+		except Exception:
 			pass				
 		try:			
 			result = self.getJCExtendedFeatures()
 			self.needKeyCache = (result['proprietaryApi'] == False)
-		except:
+		except Exception:
 			pass
 
 	def setAlternateCoinVersion(self, versionRegular, versionP2SH):
@@ -298,7 +298,7 @@ class btchip:
 					response = self.dongle.exchange(bytearray(apdu))
 					offset += dataLength
 				alternateEncoding = True
-			except:
+			except Exception:
 				pass
 		if not alternateEncoding:
 			apdu = [ self.BTCHIP_CLA, self.BTCHIP_INS_HASH_INPUT_FINALIZE, 0x02, 0x00 ]

--- a/btchip/btchipComm.py
+++ b/btchip/btchipComm.py
@@ -142,7 +142,7 @@ class HIDDongleHIDAPI(Dongle, DongleWait):
 		if self.opened:
 			try:
 				self.device.close()
-			except:
+			except Exception:
 				pass
 		self.opened = False
 
@@ -169,7 +169,7 @@ class DongleSmartcard(Dongle):
 		if self.opened:
 			try:
 				self.device.disconnect()
-			except:
+			except Exception:
 				pass
 		self.opened = False
 
@@ -182,7 +182,7 @@ class DongleServer(Dongle):
 		self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 		try:
 			self.socket.connect((self.server, self.port))
-		except:
+		except Exception:
 			raise BTChipException("Proxy connection failed")
 
 	def exchange(self, apdu, timeout=20000):
@@ -202,7 +202,7 @@ class DongleServer(Dongle):
 	def close(self):
 		try:
 			self.socket.close()
-		except:
+		except Exception:
 			pass
 
 def getDongle(debug=False):
@@ -244,7 +244,7 @@ def getDongle(debug=False):
 				else:
 					connection.disconnect()
 					connection = None
-			except:
+			except Exception:
 				connection = None
 				pass
 		if connection is not None:

--- a/btchip/btchipKeyRecovery.py
+++ b/btchip/btchipKeyRecovery.py
@@ -52,6 +52,6 @@ def recoverKey(signature, hashValue, keyX):
 			candidate = point_to_ser(key.pubkey.point)
 			if candidate[1:33] == keyX:
 				return candidate
-		except:
+		except Exception:
 			pass
 	raise Exception("Key recovery failed")

--- a/btchip/btchipPersoWizard.py
+++ b/btchip/btchipPersoWizard.py
@@ -25,7 +25,7 @@ from PyQt4.QtGui import QDialog, QMessageBox
 try:
 	from mnemonic import Mnemonic
 	MNEMONIC = True
-except:
+except Exception:
 	MNEMONIC = False
 
 from .btchipComm import getDongle, DongleWait
@@ -51,7 +51,7 @@ def waitDongle(currentDialog, persoData):
 		if persoData['client'] != None:
 			try:
 				persoData['client'].dongle.close()
-			except:
+			except Exception:
 				pass
 		dongle = getDongle(BTCHIP_DEBUG)
 		persoData['client'] = btchip(dongle)
@@ -124,7 +124,7 @@ class SeedDialog(QtGui.QDialog):
 				seedText = seedText[0:-1]
 			try:
 				self.persoData['seed'] = seedText.decode('hex')
-			except:
+			except Exception:
 				pass
 			if self.persoData['seed'] == None:
 				if not MNEMONIC:
@@ -279,7 +279,7 @@ class FinalizeDialog(QtGui.QDialog):
 		if not self.persoData['hardened']:
 			try:
 				self.persoData['client'].setOperationMode(btchip.OPERATION_MODE_SERVER)
-			except:
+			except Exception:
 				QMessageBox.warning(self, "Error", "Error switching to non hardened mode", "OK")
 				self.reject()
 				self.persoData['main'].reject()

--- a/samples/runScript.py
+++ b/samples/runScript.py
@@ -45,7 +45,7 @@ while line:
 		if len(line) == 0:
 			continue
 		dongle.exchange(bytearray(binascii.unhexlify(line)), timeout)
-	except:
+	except Exception:
 		if cancelResponse:
 			pass
 		else:

--- a/tests/testMessageSignature.py
+++ b/tests/testMessageSignature.py
@@ -34,7 +34,7 @@ dongle = getDongle(True)
 app = btchip(dongle)
 try:
 	app.setup(btchip.OPERATION_MODE_WALLET, btchip.FEATURE_RFC6979, 0x00, 0x05, "1234", None, btchip.QWERTY_KEYMAP, SEED)
-except:
+except Exception:
 	pass
 # Authenticate
 app.verifyPin("1234")

--- a/tests/testMultisigArmory.py
+++ b/tests/testMultisigArmory.py
@@ -138,7 +138,7 @@ dongle = getDongle(True)
 app = btchip(dongle)
 try:
   app.setup(btchip.OPERATION_MODE_RELAXED_WALLET, btchip.FEATURE_RFC6979, 111, 196, "1234", None, btchip.QWERTY_KEYMAP, SEED)
-except:
+except Exception:
   pass
 # Authenticate
 app.verifyPin("1234")

--- a/tests/testMultisigArmoryNo2FA.py
+++ b/tests/testMultisigArmoryNo2FA.py
@@ -136,7 +136,7 @@ dongle = getDongle(True)
 app = btchip(dongle)
 try:
   app.setup(btchip.OPERATION_MODE_RELAXED_WALLET, btchip.FEATURE_RFC6979|btchip.FEATURE_NO_2FA_P2SH, 111, 196, "1234", None, btchip.QWERTY_KEYMAP, SEED)
-except:
+except Exception:
   pass
 # Authenticate
 app.verifyPin("1234")

--- a/tests/testSimpleTransaction.py
+++ b/tests/testSimpleTransaction.py
@@ -39,7 +39,7 @@ dongle = getDongle(True)
 app = btchip(dongle)
 try:
 	app.setup(btchip.OPERATION_MODE_WALLET, btchip.FEATURE_RFC6979, 0x00, 0x05, "1234", None, btchip.QWERTY_KEYMAP, SEED)
-except:
+except Exception:
 	pass
 # Authenticate
 app.verifyPin("1234")


### PR DESCRIPTION
Using a bare `except:` is not a good coding practice: it catches all exceptions inheriting from `BaseException`, including `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` (which is not an error and should not normally be caught by user code).
```
BaseException
  - Exception
  - GeneratorExit
  - KeyboardInterrupt
  - SystemExit
```
This patch is sub-optimal because only specific exceptions should be catched... anyway, in situations where one wants to catch all “normal” exceptions, at least restrict to explicitly catch the `Exception` base class, instead of implicitly catching any BaseException.

See also: https://github.com/bitcoin-core/HWI/pull/373