### PR TITLE
Fix smartcard pyscard dependency versions and name

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
     packages=find_packages(),
     install_requires=['hidapi>=0.7.99', 'ecdsa>=0.9'],
     extras_require = {
-	'smartcard': [ 'python-pyscard>=1.6.12-4build1' ]
+	'smartcard': [ 'pyscard>=1.6.12' ]
     },
     include_package_data=True,
     zip_safe=False,


### PR DESCRIPTION
The version specification is invalid with recent setuptools and also the package name is `pyscard`.

See https://github.com/pypa/setuptools/issues/3801

fixes #53